### PR TITLE
Interest section

### DIFF
--- a/portfolio/src/main/webapp/index.html
+++ b/portfolio/src/main/webapp/index.html
@@ -51,11 +51,76 @@
                     thinking skills sharp even when I'm winding down. However, entertainment
                     has also been a source of inspiration for me. Science fiction and
                     fantasy allow us to imagine what the world could be like, and often 
-                    inspire me to contemplate how possible some fictional technolgies.    
-                </p>
+                    inspire me to contemplate how possible some fictional technolgies.</p>
             </div>
             <div class="gallery">
                 <a href="images/Mathew_1.jpg"><img class="gallery-img" src="images/Mathew_1.jpg" alt="Mathew Suarez Headshot"/></a>
+            </div>
+        </div>
+
+        <div class="section-header">
+            <h1>Interests</h1>
+        </div>
+        <div class="sections" id="interests">
+            <div class="interest-container">
+                <div class="interest-img-container">
+                    <a href="images/Mathew_1.jpg"><img class="gallery-img" src="images/Mathew_1.jpg" alt="Mathew Suarez Headshot"/></a>
+                </div>
+                <div class="interest-text">
+                    <p>This is the first interest box bleh. Ignore me.
+                        This is the first interest box bleh. Ignore me.
+                        This is the first interest box bleh. Ignore me.
+                        This is the first interest box bleh. Ignore me.
+                        This is the first interest box bleh. Ignore me.
+                        This is the first interest box bleh. Ignore me.
+                        This is the first interest box bleh. Ignore me.
+                        This is the first interest box bleh. Ignore me.</p>
+                </div>
+            </div>
+            <div class="interest-container">
+                <div class="interest-img-container">
+                    <a href="images/Mathew_1.jpg"><img class="gallery-img" src="images/Mathew_1.jpg" alt="Mathew Suarez Headshot"/></a>
+                </div>
+                <div class="interest-text">
+                    <p>This is the second interest box bleh. Ignore me.
+                        This is the second interest box bleh. Ignore me.
+                        This is the second interest box bleh. Ignore me.
+                        This is the second interest box bleh. Ignore me.
+                        This is the second interest box bleh. Ignore me.
+                        This is the second interest box bleh. Ignore me.
+                        This is the second interest box bleh. Ignore me.
+                        This is the second interest box bleh. Ignore me.</p>
+                </div>
+            </div>
+            <div class="interest-container">
+                <div class="interest-img-container">
+                    <a href="images/Mathew_1.jpg"><img class="gallery-img" src="images/Mathew_1.jpg" alt="Mathew Suarez Headshot"/></a>
+                </div>
+                <div class="interest-text">
+                    <p>This is the third interest box bleh. Ignore me.
+                        This is the third interest box bleh. Ignore me.
+                        This is the third interest box bleh. Ignore me.
+                        This is the third interest box bleh. Ignore me.
+                        This is the third interest box bleh. Ignore me.
+                        This is the third interest box bleh. Ignore me.
+                        This is the third interest box bleh. Ignore me.
+                        This is the third interest box bleh. Ignore me.</p>
+                </div>
+            </div>
+            <div class="interest-container">
+                <div class="interest-img-container">
+                    <a href="images/Mathew_1.jpg"><img class="gallery-img" src="images/Mathew_1.jpg" alt="Mathew Suarez Headshot"/></a>
+                </div>
+                <div class="interest-text">
+                    <p>This is the fourth interest box bleh. Ignore me.
+                        This is the fourth interest box bleh. Ignore me.
+                        This is the fourth interest box bleh. Ignore me.
+                        This is the fourth interest box bleh. Ignore me.
+                        This is the fourth interest box bleh. Ignore me.
+                        This is the fourth interest box bleh. Ignore me.
+                        This is the fourth interest box bleh. Ignore me.
+                        This is the fourth interest box bleh. Ignore me.</p>
+                </div>
             </div>
         </div>
   </body>

--- a/portfolio/src/main/webapp/index.html
+++ b/portfolio/src/main/webapp/index.html
@@ -30,9 +30,29 @@
         </div>
         <div class="sections" id="about">
             <div class="left-side-text-container text-container">
-                <p>Insert About Text. I am sample text ignore me please, blah. I am sample text ignore me please, blah.
-                    I am sample text ignore me please, blah. I am sample text ignore me please, blah.
-                    I am sample text ignore me please, blah. I am sample text ignore me please, blah.</p>
+                <p>I was born in the US and was raised here in Georgia until I was 11 
+                    yeras old. My parents are from Colombia, but in 2011 they moved back
+                    and I went with them. I lived there for 6 years in the city of Bogota
+                    before moving back to the US with my great aunt so I could finish high 
+                    school, find better opportunities to succeed professionally, and 
+                    attend a better university than I would have been able to afford in 
+                    Colombia.<br>
+                    From a young age I was interested in technology and knew I wanted to 
+                    learn to create amazing products. At that time, I thought I would grow
+                    up to become an engineer. It wasn't until high school that I learned 
+                    about computer science and programming, and soon I knew that I wanted 
+                    to have a career in software. This interest in the field that pushed me
+                    to be part of CSSI in 2019, and return to Google as a STEP intern in 2020.
+                    Currently, I am a Computer Science student at the University of 
+                    Gerogia with a minor in Cognitive Science.<br> 
+                    In my free time, I enjoy watching super hero movies and playing vdeo games.
+                    I especially enjoy stategy games or base building games where I get to
+                    find creative solutions to problems and can help me keep my critical 
+                    thinking skills sharp even when I'm winding down. However, entertainment
+                    has also been a source of inspiration for me. Science fiction and
+                    fantasy allow us to imagine what the world could be like, and often 
+                    inspire me to contemplate how possible some fictional technolgies.    
+                </p>
             </div>
             <div class="gallery">
                 <a href="images/Mathew_1.jpg"><img class="gallery-img" src="images/Mathew_1.jpg" alt="Mathew Suarez Headshot"/></a>

--- a/portfolio/src/main/webapp/index.html
+++ b/portfolio/src/main/webapp/index.html
@@ -7,14 +7,14 @@
     <script src="script.js"></script>
   </head>
   <body>
-        <div class="sectionheader">
+        <div class="section-header">
             <h1>Welcome</h1>
         </div>
         <div class="sections" id="welcome">
             <div class="gallery">
-                <a href="images/Mathew_1.jpg"><img class="galleryimg" src="images/Mathew_1.jpg" alt="Mathew Suarez Headshot"/></a>
+                <a href="images/Mathew_1.jpg"><img class="gallery-img" src="images/Mathew_1.jpg" alt="Mathew Suarez Headshot"/></a>
             </div>
-            <div class="RightSideTextContainer textcontainer">
+            <div class="right-side-text-container text-container">
                 <p>Welcome to my portfolio! My name is Mathew Suarez. I am currently a
                     Google STEP intern, and as part of my work training I have 
                     put together this portfolio to indtroduce myself, my interests,
@@ -25,17 +25,17 @@
             </div>
         </div>
      
-        <div class="sectionheader">
+        <div class="section-header">
             <h1>About Me</h1>
         </div>
         <div class="sections" id="about">
-            <div class="LeftSideTextContainer textcontainer">
+            <div class="left-side-text-container text-container">
                 <p>Insert About Text. I am sample text ignore me please, blah. I am sample text ignore me please, blah.
                     I am sample text ignore me please, blah. I am sample text ignore me please, blah.
                     I am sample text ignore me please, blah. I am sample text ignore me please, blah.</p>
             </div>
             <div class="gallery">
-                <a href="images/Mathew_1.jpg"><img class="galleryimg" src="images/Mathew_1.jpg" alt="Mathew Suarez Headshot"/></a>
+                <a href="images/Mathew_1.jpg"><img class="gallery-img" src="images/Mathew_1.jpg" alt="Mathew Suarez Headshot"/></a>
             </div>
         </div>
   </body>

--- a/portfolio/src/main/webapp/style.css
+++ b/portfolio/src/main/webapp/style.css
@@ -1,3 +1,16 @@
+#about,
+#interests,
+#welcome {
+    border: 1px solid rgba(94, 94, 94, 0.7);
+}
+
+#about,
+#welcome {
+    align-items: center;
+    display: flex;
+    justify-content: center;
+}
+
 .gallery {
     align-items: center;
     display: flex;
@@ -20,6 +33,47 @@ h1 {
     text-align: center;
 }
 
+#interests {
+    align-items: flex-start;
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: space-evenly;
+}
+
+.interest-container {
+    border: 1px solid rgba(94, 94, 94, 0.7);
+    box-sizing: border-box;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    margin: 30px;
+    max-width: 550px;
+    padding: 20px;
+}
+
+.interest-img {
+    max-height: 100%;
+    max-width: 100%;
+}
+
+.interest-img-container {
+    max-height: 60%;
+    padding: 15px;
+}
+
+.interest-img-container,
+.interest-text {
+    box-sizing: border-box;
+    max-width: 100%;
+}
+
+.interest-text {
+    font-size: 22px;
+    min-width: 200px;
+    margin: 5px 0px 0px 0px;
+    text-align: justify;
+}
+
 .left-side-text-container {
     margin: 0px 40px 0px 0px;
 }
@@ -29,14 +83,11 @@ h1 {
 }
 
 .sections {
-    align-items: center;
     box-sizing: border-box;
-    display: flex;
-    justify-content: center;
     margin: 0px 100px 125px 100px;
     max-width: auto;
     min-width: 765px;
-    padding: 20px;
+    padding: 30px;
 }
 
 .section-header {
@@ -55,10 +106,4 @@ h1 {
 .gallery {
     box-sizing: border-box;
     display: flex;
-}
-
-#about,
-#interests,
-#welcome {
-    border: 1px solid rgba(94, 94, 94, 0.7);
 }

--- a/portfolio/src/main/webapp/style.css
+++ b/portfolio/src/main/webapp/style.css
@@ -29,11 +29,11 @@ h1 {
 }
 
 .sections {
+    align-items: center;
     box-sizing: border-box;
     display: flex;
     justify-content: center;
     margin: 0px 100px 125px 100px;
-    max-height: 1100px;
     max-width: auto;
     min-width: 765px;
     padding: 20px;
@@ -58,6 +58,7 @@ h1 {
 }
 
 #about,
+#interests,
 #welcome {
     border: 1px solid rgba(94, 94, 94, 0.7);
 }

--- a/portfolio/src/main/webapp/style.css
+++ b/portfolio/src/main/webapp/style.css
@@ -8,7 +8,7 @@
     min-height: 300px; 
 }
 
-.galleryimg {
+.gallery-img {
     display: block;
     max-width: 100%;
     max-height: 100%;
@@ -20,11 +20,11 @@ h1 {
     text-align: center;
 }
 
-.LeftSideTextContainer {
+.left-side-text-container {
     margin: 0px 40px 0px 0px;
 }
 
-.RightSideTextContainer {
+.right-side-text-container {
     margin: 0px 0px 0px 40px;
 }
 
@@ -39,19 +39,19 @@ h1 {
     padding: 20px;
 }
 
-.sectionheader {
+.section-header {
     max-width: auto;
     min-width: 965px;
 }
 
-.textcontainer {
+.text-container {
     font-size: 25px;
     max-width: 720px;
     min-width: 400px;
     text-align: justify;
 }
 
-.textcontainer, 
+.text-container, 
 .gallery {
     box-sizing: border-box;
     display: flex;


### PR DESCRIPTION
Added the interest section, which can currently support the adding of future interest cards (labeled as containers in code) without any errors to display (e.g. overflow or overlap). Also handles the resizing of the window to still display these interest cards depending on browser size. 
This PR also includes a minor change which is the naming of CSS ids and classes, which previously were not following the Google style guidelines.

![image](https://user-images.githubusercontent.com/42452832/83442426-2712ca00-a416-11ea-8412-3e2a95db4b70.png)
![image](https://user-images.githubusercontent.com/42452832/83442470-3a259a00-a416-11ea-9aec-40410c640940.png)
![image](https://user-images.githubusercontent.com/42452832/83442514-4ad61000-a416-11ea-80fb-abd46c875b49.png)
